### PR TITLE
fix: Use dynamic username for Docker image tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,4 +23,4 @@ jobs:
       with:
         context: .
         push: true
-        tags: sruckh/mtvcraft-runpod:latest
+        tags: ${{ secrets.DOCKERHUB_USERNAME }}/mtvcraft-runpod:latest


### PR DESCRIPTION
This pull request fixes the 'access denied' error during the Docker push. It updates the workflow to dynamically use the  secret in the image tag, ensuring the logged-in user has permission to push to the target repository.