### PR TITLE
fix: Use NVIDIA CUDA base image for DeepSpeed build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
-# Use the official Python 3.10 slim image
-FROM python:3.10-slim
+# Use an official NVIDIA CUDA 12.1.1 development image as the base
+# The -devel tag is crucial as it includes the full CUDA Toolkit needed for compilation.
+FROM nvidia/cuda:12.1.1-devel-ubuntu22.04
+
+# Set environment variables to prevent interactive prompts during installation
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+
+# Install Python 3.10, pip, and other basic tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.10 \
+    python3-pip \
+    python-is-python3 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -11,7 +23,6 @@ COPY . .
 RUN chmod +x runpod-startup.sh
 
 # Set environment variables that will be passed from RunPod
-# An empty default value is provided, but these should be set in the RunPod template.
 ENV LLM_MODEL_NAME="qwen-plus"
 ENV LLM_API_KEY=""
 ENV LLM_BASE_URL="https://dashscope.aliyuncs.com/compatible-mode/v1"
@@ -19,4 +30,6 @@ ENV ELEVENLABS_KEY=""
 ENV HF_TOKEN=""
 
 # Set the command to run the startup script
+# This script will install dependencies and launch the app
 CMD ["./runpod-startup.sh"]
+


### PR DESCRIPTION
This pull request fixes the  error.

**Problem:** The application was failing because  requires the full NVIDIA CUDA Toolkit to compile custom ops, but the previous  base image did not contain it.

**Solution:**
- Changed the base image in the  to .
- This official NVIDIA image includes the complete CUDA Toolkit and correctly sets the  environment variable, allowing  to build its operations successfully.