### PR TITLE
fix(deps): add python3.10-dev to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV PYTHONUNBUFFERED=1
 # Install Python 3.10, pip, and other basic tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3.10 \
+    python3.10-dev \
     python3-pip \
     python-is-python3 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The insightface package requires the Python C development headers to build its C extensions. Without the `python3.10-dev` package, the build fails with a "Python.h: No such file or directory" error.

This change adds the missing dependency to the Dockerfile to ensure the build environment is complete.